### PR TITLE
Cleaning cache needs to be forced

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,7 +8,7 @@ console.log('\nRemoving node_modules directory ...');
 rimraf('node_modules', {}, function () {
     console.log('Cleaning NPM cache ..');
     
-    spawn('npm', ['cache', 'clean'], { stdio: ['pipe', 'pipe', process.stderr] })
+    spawn('npm', ['cache', 'clean', '--force'], { stdio: ['pipe', 'pipe', process.stderr] })
       .on('close', function () {
         
         console.log('Installing dependencies ...');


### PR DESCRIPTION
As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.

If you're sure you want to delete the entire cache, rerun this command with --force.